### PR TITLE
Added an api/list file to simulate module list coming from master

### DIFF
--- a/api/list
+++ b/api/list
@@ -1,0 +1,24 @@
+{
+    "agentList": {
+        "60:01:94:06:80:51": {
+            "name": "Ventilo",
+            "ip": "192.168.4.4",
+            "canSleep": false,
+            "connected": 0,
+            "uiClassName": "fanUIClass",
+            "heap": 39136,
+            "pingPeriod": 0,
+            "custom": "{\"speed\":0, \"osc\":\"off\"}"
+        },
+        "84:f3:eb:96:82:aa": {
+            "name": "Lampe",
+            "ip": "192.168.4.3",
+            "canSleep": false,
+            "connected": 0,
+            "uiClassName": "switchUIClass",
+            "heap": 39736,
+            "pingPeriod": 0,
+            "custom": "{\"status\":\"off\"}"
+        }
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,17 +7,24 @@ import Module from './data/Module.js'
 import ModuleList from './data/ModuleList.js'
 import ModuleListView from './Components/ModuleList.jsx'
 
-import SAMPLE_DATA from './sample.js'
+//import SAMPLE_DATA from './sample.js'
 
 const store = new ModuleList()
-Object.entries(SAMPLE_DATA).forEach(([k, v]) =>
-  store.modules.push(
-    new Module({
-      MAC: k,
-      ...v
-    })
-  )
-)
+
+fetch(document.location.origin + '/api/list')
+  .then(response => response.json())
+  .then(data => {
+    Object.entries(data.agentList).forEach(([k, v]) =>
+      store.modules.push(
+        new Module({
+          MAC: k,
+          ...v
+        })
+      )
+    )
+    render(<App />, document.getElementById('app'))
+  })
+
 //console.log(store.modules.slice())
 let idx = 2
 const App = observer(() => (
@@ -47,7 +54,6 @@ const App = observer(() => (
   </React.Fragment>
 ))
 
-render(<App />, document.getElementById('app'))
 if (process.env.NODE_ENV === 'development') {
   // DEBUG: expose the store (module list in window to test outside of the UI)
   // Ex: window.store.modules[0].customData.speed = "5"


### PR DESCRIPTION
Now fetching module list from api/list rather than from a variable.
Added an 'api' directory with a 'list' file to simulate while in dev mode.
iotinator master was updated to serve this app's loader page, so with this modification the app loads the real master's module list.